### PR TITLE
Configure environment-specific RabbitMQ properties

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,4 +1,4 @@
-server.port = 8000
+server.port = 6000
 
 #Database
 spring.datasource.url=${DB_DEV_URL}
@@ -16,3 +16,9 @@ spring.mail.username=${MAILTRAP_USERNAME}
 spring.mail.password=${MAILTRAP_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=false
+
+#Messaging Queue
+spring.rabbitmq.host=${RABBITMQ_HOST}
+spring.rabbitmq.port=${RABBITMQ_PORT}
+spring.rabbitmq.username=${RABBITMQ_USERNAME}
+spring.rabbitmq.password=${RABBITMQ_PASSWORD}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -16,3 +16,10 @@ spring.mail.username=${MAILTRAP_USERNAME}
 spring.mail.password=${MAILTRAP_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+#Messaging Queue
+spring.rabbitmq.host=${RABBITMQ_HOST_LIVE}
+spring.rabbitmq.port=${RABBITMQ_PORT_LIVE}
+spring.rabbitmq.username=${RABBITMQ_USERNAME_LIVE}
+spring.rabbitmq.password=${RABBITMQ_PASSWORD_LIVE}
+spring.rabbitmq.ssl.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,8 +10,3 @@ security.jwt.expiration-time=${JWT_EXPIRATION_TIME}
 cloudinary.cloud_name=${CLOUDINARY_CLOUD_NAME}
 cloudinary.api_key=${CLOUDINARY_API_KEY}
 cloudinary.api_secret=${CLOUDINARY_API_SECRET}
-
-spring.rabbitmq.host=localhost
-spring.rabbitmq.port=5672
-spring.rabbitmq.username=guest
-spring.rabbitmq.password=guest


### PR DESCRIPTION
Move RabbitMQ configuration out of the shared application properties file and into the dev and prod profile-specific property files. This keeps local/default configuration from being hardcoded globally and allows each environment to resolve its queue connection details from environment variables.

Changes include:
- Removed default localhost RabbitMQ settings from application.properties
- Added RabbitMQ connection properties to application-dev.properties using development environment variables
- Added RabbitMQ connection properties to application-prod.properties using live environment variables
- Enabled SSL for RabbitMQ in the production profile
- Updated the development server port from 8000 to 6000

This makes messaging configuration profile-aware and better suited for deployment environments where credentials and host details are supplied externally.